### PR TITLE
Fix bug in multi_predict() with a single component value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ Config/usethis/last-upkeep: 2025-04-27
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Transition from the magrittr pipe to the base R pipe.
 
+* Fixed a bug (exposed by the new version of the tune package) where `multi_predict()` was called with a single component value (#47).
+
 # plsmod 1.0.0
 
 * Small release to correct HTML tags for CRAN.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -3,6 +3,7 @@ Codecov
 Lifecycle
 ORCID
 PBC
+ROR
 RStudio
 Rohart
 Tecator
@@ -10,7 +11,6 @@ al
 doi
 et
 funder
-loadings
 magrittr
 mixOmics
 modeldata

--- a/man/plsmod-package.Rd
+++ b/man/plsmod-package.Rd
@@ -22,7 +22,7 @@ Useful links:
 
 Other contributors:
 \itemize{
-  \item Posit Software, PBC (03wc8by49) [copyright holder, funder]
+  \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]
 }
 
 }

--- a/tests/testthat/_snaps/pls.md
+++ b/tests/testthat/_snaps/pls.md
@@ -1,0 +1,10 @@
+# check_args() works
+
+    Code
+      spec <- set_mode(set_engine(parsnip::pls(num_comp = -1), "mixOmics"),
+      "regression")
+      fit(spec, mpg ~ ., data = mtcars)
+    Condition
+      Error in `fit()`:
+      ! `num_comp` must be a whole number larger than or equal to 0 or `NULL`, not the number -1.
+

--- a/tests/testthat/helper-objects.R
+++ b/tests/testthat/helper-objects.R
@@ -1,8 +1,7 @@
 suppressPackageStartupMessages(library(mixOmics))
 
 if (rlang::is_installed("modeldata")) {
-  data("penguins", package = "modeldata")
-  penguins <- na.omit(penguins)
+  penguins <- na.omit(modeldata::penguins)
 
   pen_for_test <- 1:10
   pen_y_tr <- penguins$species[-pen_for_test]
@@ -20,14 +19,10 @@ if (rlang::is_installed("modeldata")) {
 
   ###
 
-  data(meats, package = "modeldata")
-
   meats_for_test <- 1:10
-  meats_y_tr <- meats[-meats_for_test, c("water", "fat", "protein")]
-  meats_y_te <- meats[meats_for_test, c("water", "fat", "protein")]
+  meats_y_tr <- modeldata::meats[-meats_for_test, c("water", "fat", "protein")]
+  meats_y_te <- modeldata::meats[meats_for_test, c("water", "fat", "protein")]
 
-  meats_x_tr <- meats[-meats_for_test, 1:100]
-  meats_x_te <- meats[meats_for_test, 1:100]
+  meats_x_tr <- modeldata::meats[-meats_for_test, 1:100]
+  meats_x_te <- modeldata::meats[meats_for_test, 1:100]
 }
-
-print("yey")

--- a/tests/testthat/test-reg-pls.R
+++ b/tests/testthat/test-reg-pls.R
@@ -122,6 +122,19 @@ test_that("mixOmics univariate model fitting", {
     ignore_attr = TRUE
   )
 
+  # multi_predict with a single component
+  expect_no_error(
+    parsnip_pls_multi_pred_num_single <-
+      multi_predict(parsnip_pls_uni, as.data.frame(meats_x_te), num_comp = 1)
+  )
+  expect_equal(nrow(parsnip_pls_multi_pred_num_single), nrow(meats_x_te))
+  expect_equal(nrow(parsnip_pls_multi_pred_num_single$.pred[[1]]), 1)
+  expect_equal(
+    names(parsnip_pls_multi_pred_num_single$.pred[[1]]),
+    c("num_comp", ".pred"),
+    ignore_attr = TRUE
+  )
+
   mo_pls_pred_9 <- predict(uni_model, meats_x_te)$predict[9, , 1:2]
   mo_pls_pred_9 <- tibble::tibble(.pred = mo_pls_pred_9)
 


### PR DESCRIPTION
Closes #47 

This bug wasn't encountered until tune version 2.0.0 was released. It is a dimension-dropping issue when a single PLS component was predicted via `multi_predict()` (and only for regression models with one outcome). 